### PR TITLE
Make diagnostic messages from ANTLR optional

### DIFF
--- a/cmd/parser/main.go
+++ b/cmd/parser/main.go
@@ -34,7 +34,7 @@ func main() {
 		}
 	}()
 
-	outCh := nlurules.ParseAsync(inputCh)
+	outCh := nlurules.ParseAsync(inputCh, false, false)
 
 	for u := range outCh {
 		fmt.Printf("Received utterance %+v\n", u)

--- a/pkg/nlurules/parser.go
+++ b/pkg/nlurules/parser.go
@@ -6,7 +6,11 @@ import (
 	"speechly/nlu-rules-parser/pkg/parser"
 )
 
-func ParseAsync(in <-chan string) <-chan Utterance {
+// ParseAsync processes input strings in a streaming fashion.
+// It assumes that a single string passed through the input channel contains a parseable utterance.
+//
+// TODO: combine logDiagnostics and verbose into a ternary log level.
+func ParseAsync(in <-chan string, logDiagnostics bool, verbose bool) <-chan Utterance {
 	listener := NewNluRuleListener()
 
 	go func() {
@@ -21,8 +25,11 @@ func ParseAsync(in <-chan string) <-chan Utterance {
 			)
 
 			p := parser.NewAnnotationGrammarParser(stream)
-			p.AddErrorListener(antlr.NewDiagnosticErrorListener(true))
 			p.BuildParseTrees = true
+
+			if logDiagnostics {
+				p.AddErrorListener(antlr.NewDiagnosticErrorListener(verbose))
+			}
 
 			antlr.ParseTreeWalkerDefault.Walk(listener, p.Annotation())
 		}


### PR DESCRIPTION
### What

Add a couple of flags to control the output of ANTLR parser diagnostic messages (they are currently disabled in CLI).

### Why

Diagnostic messages aren't always useful and usually are only needed for debugging.
