### PR TITLE
Remove internal listener buffer and change Node to be a struct

### DIFF
--- a/pkg/nlurules/utterance.go
+++ b/pkg/nlurules/utterance.go
@@ -1,0 +1,29 @@
+package nlurules
+
+// TODO: make these custom types
+const (
+	IntentTagBeginning = "b"
+	IntentTagInside    = "i"
+	IntentTagOutside   = "o"
+)
+
+type Node struct {
+	Text      string `json:"text"`
+	Entity    string `json:"entity"`
+	Intent    string `json:"intent"`
+	IntentBIO string `json:"intent_bio"`
+}
+
+type Utterance struct {
+	Nodes     []Node `json:"parsed"`
+	Entity    string `json:"-"`
+	Intent    string `json:"-"`
+	IntentBIO string `json:"-"`
+}
+
+func NewUtterance() Utterance {
+	return Utterance{
+		IntentBIO: IntentTagOutside,
+		Nodes:     make([]Node, 1), // TODO: figure out how much we want to pre-allocate here
+	}
+}


### PR DESCRIPTION
### What

1. Remove internal listener buffer.
2. Change Node from `map[string]string` to a `struct` instead.
3. Re-write CLI client to use streaming parser and make it error-prone.

### Why

1. Having an unbounded buffer like that can cause huge memory consumption (since every line is stored there, a file with 10^9 lines will make the program allocate a lot of memory), even though the parser only relies on the channel as a buffer.
2. Having a special struct instead of a map makes it more efficient (both CPU and memory wise) and more readable.
3. So that CLI is more readable and doesn't panic on unexpected errors.


EDIT: Forgot to mention that listener now is safe for concurrent usage, since it uses a mutex for RW operations on its state.