### PR TITLE
Remove redundant empty node in utterances

### DIFF
--- a/internal/grammar/utterance.go
+++ b/internal/grammar/utterance.go
@@ -24,6 +24,6 @@ type Utterance struct {
 func NewUtterance() Utterance {
 	return Utterance{
 		IntentBIO: IntentTagOutside,
-		Nodes:     make([]Node, 1), // TODO: figure out how much we want to pre-allocate here
+		Nodes:     make([]Node, 0, 1), // TODO: figure out how much we want to pre-allocate here
 	}
 }


### PR DESCRIPTION
### What

Remove redundant empty node in utterances.

### Why

To fix the bug with parser prepending extra empty node for each utterance.

