### PR TITLE
Force cgo usage in test Makefile target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ all: compile-grammar test build
 .PHONY: all
 
 test:
-	go test -race -cover -covermode=atomic -v $(GOPKGS)
+	CGO_ENABLED=1 go test -race -cover -covermode=atomic -v $(GOPKGS)
 .PHONY: test
 
 build:


### PR DESCRIPTION
### What

Force cgo usage in test Makefile target by adding `CGO_ENABLED=1`.

### Why

Somehow it is not explicitly forced and `make test` fails in Github actions:
```sh
go test -race -cover -covermode=atomic -v speechly/nlu-example-parser/cmd/parser speechly/nlu-example-parser/internal/grammar speechly/nlu-example-parser/pkg/parser
go test: -race requires cgo; enable cgo by setting CGO_ENABLED=1
make: *** [test] Error 2
```

See the logs at https://pipelines.actions.githubusercontent.com/KIomjBfPxbsH2Taue8cQQhlFgB5NA3RybBoTP11xalANKPWbYk/_apis/pipelines/1/runs/22/signedlogcontent/4?urlExpires=2020-03-04T11%3A12%3A00.1363314Z&urlSigningMethod=HMACV1&urlSignature=rUW%2F3pm29uK2kDW5npciU2MAbzM8UztdsXO%2B2oIXz34%3D