### PR TITLE
Fix release build and update README

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,8 +30,8 @@ jobs:
           GONAME: speechly-nluexamplesparser-${{ steps.get_build_version.outputs.VERSION }}-${{ matrix.os }}-${{ matrix.arch }}
         run: |
           make test && \
+          make verify && \
           make build -e && \
-          make verify -e && \
           tar -czvf ${GONAME}.tar.gz ${GONAME}
       - name: "Upload build artifact"
         uses: actions/upload-artifact@v1

--- a/cmd/parser/main.go
+++ b/cmd/parser/main.go
@@ -7,7 +7,7 @@ import (
 	"io"
 	"os"
 
-	"speechly/nlu-example-parser/pkg/parser"
+	"github.com/speechly/nlu-example-parser/pkg/parser"
 
 	"golang.org/x/sync/errgroup"
 )

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module speechly/nlu-example-parser
+module github.com/speechly/nlu-example-parser
 
 go 1.13
 

--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -3,7 +3,7 @@ package parser
 import (
 	"github.com/antlr/antlr4/runtime/Go/antlr"
 
-	"speechly/nlu-example-parser/internal/grammar"
+	"github.com/speechly/nlu-example-parser/internal/grammar"
 )
 
 type Parser struct {

--- a/pkg/parser/stream_parser.go
+++ b/pkg/parser/stream_parser.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"errors"
 
-	"speechly/nlu-example-parser/internal/grammar"
+	"github.com/speechly/nlu-example-parser/internal/grammar"
 )
 
 type StreamParser struct {


### PR DESCRIPTION
### What

1. Add `github.com` to module name
2. Change `make verify` step in release build
3. Update README with new instructions on how to use CLI / library

### Why

1. `go get` complains about module name:
```
go get github.com/speechly/nlu-example-parser
go: finding github.com/speechly/nlu-example-parser v0.2.0
go: downloading github.com/speechly/nlu-example-parser v0.2.0
go: extracting github.com/speechly/nlu-example-parser v0.2.0
go get: github.com/speechly/nlu-example-parser@v0.2.0: parsing go.mod:
	module declares its path as: speechly/nlu-example-parser
	        but was required as: github.com/speechly/nlu-example-parser
```
2. Release build is broken because of verification step - it's trying to run non-linux binaries on linux.
3. Readme is currently missing instructions on how to properly use CLI and install the library.
