### PR TITLE
Change release build naming and fix verification step

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -8,9 +8,23 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: ["darwin", "linux", "freebsd"]
+        arch: ["386", "amd64"]
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-go@v1
+      - name: "Checkout repo"
+        uses: actions/checkout@v2
+      - name: "Setup Go environment"
+        uses: actions/setup-go@v1
         with:
           go-version: "1.13"
-      - run: make
+      - name: "Run build & tests"
+        env:
+          BUILDOS: ${{ matrix.os }}
+          BUILDARCH: ${{ matrix.arch }}
+          BUILDNAME: parser-${{ matrix.os }}-${{ matrix.arch }}
+        run: |
+          make test && \
+          make verify && \
+          make build -e

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,9 +14,6 @@ jobs:
         os: ["darwin", "linux", "freebsd"]
         arch: ["386", "amd64"]
     steps:
-      - name: "Get build version"
-        id: get_build_version
-        run: echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\//}
       - name: "Checkout repo"
         uses: actions/checkout@v2
       - name: "Setup Go environment"
@@ -25,19 +22,19 @@ jobs:
           go-version: "1.13"
       - name: "Create build artifact"
         env:
-          GOOS: ${{ matrix.os }}
-          GOARCH: ${{ matrix.arch }}
-          GONAME: speechly-nluexamplesparser-${{ steps.get_build_version.outputs.VERSION }}-${{ matrix.os }}-${{ matrix.arch }}
+          BUILDOS: ${{ matrix.os }}
+          BUILDARCH: ${{ matrix.arch }}
+          BUILDNAME: speechly-nluexampleparser-${{ matrix.os }}-${{ matrix.arch }}
         run: |
           make test && \
           make verify && \
           make build -e && \
-          tar -czvf ${GONAME}.tar.gz ${GONAME}
+          tar -czvf ${BUILDNAME}.tar.gz ${BUILDNAME}
       - name: "Upload build artifact"
         uses: actions/upload-artifact@v1
         with:
-          name: speechly-nluexamplesparser-${{ steps.get_build_version.outputs.VERSION }}-${{ matrix.os }}-${{ matrix.arch }}.tar.gz
-          path: speechly-nluexamplesparser-${{ steps.get_build_version.outputs.VERSION }}-${{ matrix.os }}-${{ matrix.arch }}.tar.gz
+          name: speechly-nluexampleparser-${{ matrix.os }}-${{ matrix.arch }}.tar.gz
+          path: speechly-nluexampleparser-${{ matrix.os }}-${{ matrix.arch }}.tar.gz
 
   create_release:
     runs-on: ubuntu-latest
@@ -71,9 +68,6 @@ jobs:
         os: ["darwin", "linux", "freebsd"]
         arch: ["386", "amd64"]
     steps:
-      - name: "Get build version"
-        id: get_build_version
-        run: echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\//}
       - name: "Download release URL file"
         uses: actions/download-artifact@v1
         with:
@@ -84,7 +78,7 @@ jobs:
       - name: "Download build artifact"
         uses: actions/download-artifact@v1
         with:
-          name: speechly-nluexamplesparser-${{ steps.get_build_version.outputs.VERSION }}-${{ matrix.os }}-${{ matrix.arch }}.tar.gz
+          name: speechly-nluexampleparser-${{ matrix.os }}-${{ matrix.arch }}.tar.gz
       - name: "Add build artifact to release"
         uses: actions/upload-release-asset@v1
         env:
@@ -96,6 +90,6 @@ jobs:
           # See this blog post for more info:
           # https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps
           upload_url: ${{ steps.get_release_url.outputs.RELEASE_UPLOAD_URL }}
-          asset_path: "speechly-nluexamplesparser-${{ steps.get_build_version.outputs.VERSION }}-${{ matrix.os }}-${{ matrix.arch }}.tar.gz/speechly-nluexamplesparser-${{ steps.get_build_version.outputs.VERSION }}-${{ matrix.os }}-${{ matrix.arch }}.tar.gz"
-          asset_name: speechly-nluexamplesparser-${{ steps.get_build_version.outputs.VERSION }}-${{ matrix.os }}-${{ matrix.arch }}.tar.gz
+          asset_path: "speechly-nluexampleparser-${{ matrix.os }}-${{ matrix.arch }}.tar.gz/speechly-nluexampleparser-${{ matrix.os }}-${{ matrix.arch }}.tar.gz"
+          asset_name: speechly-nluexampleparser-${{ matrix.os }}-${{ matrix.arch }}.tar.gz
           asset_content_type: application/gzip

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,10 @@
-ANTLR_JAR	:= ./tools/antlr-4.8-complete.jar
 GOPKGS		:= $(shell go list ./... | grep -v "/test")
-GOOS			:= darwin
-GOARCH		:= amd64
-GONAME		:= ./bin/parser
+
+BUILDOS		:= darwin
+BUILDARCH	:= amd64
+BUILDNAME	:= ./bin/parser
+
+ANTLR_JAR	:= ./tools/antlr-4.8-complete.jar
 
 all: compile-grammar test build verify
 .PHONY: all
@@ -19,10 +21,10 @@ static-build:
 	CGO_ENABLED=0 go build -o ./bin/golden ./cmd/parser
 .PHONY: static-build
 
-build: $(GONAME)
+build: $(BUILDNAME)
 
-$(GONAME): compile-grammar
-	CGO_ENABLED=0 GOOS=$(GOOS) GOARCH=$(GOARCH) go build -o $(GONAME) ./cmd/parser
+$(BUILDNAME): compile-grammar
+	CGO_ENABLED=0 GOOS=$(BUILDOS) GOARCH=$(BUILDARCH) go build -o $(BUILDNAME) ./cmd/parser
 
 compile-grammar: $(ANTLR_JAR)
 	java -jar $(ANTLR_JAR) -Dlanguage=Go -package grammar internal/grammar/AnnotationGrammar.g4

--- a/README.md
+++ b/README.md
@@ -35,10 +35,17 @@ You can check out [some example rules](examples/test_multi_intent_data.md) and [
 Pre-built binaries are automatically compiled on every release - https://github.com/speechly/nlu-example-parser/releases, you can download them using e.g. `curl`:
 
 ```sh
+# amd64 or 386
 $ export ARCH="amd64"
+
+# darwin, linux, freebsd
 $ export PLATFORM="darwin"
-$ export VERSION="v0.1.0"
-$ export FILENAME="speechly-nluexamplesparser-${VERSION}-${PLATFORM}-${ARCH}.tar.gz"
+
+# for latest version just use "latest"
+$ export VERSION="v0.2.0"
+
+# Download and unpack
+$ export FILENAME="speechly-nluexamplesparser-${PLATFORM}-${ARCH}.tar.gz"
 $ curl -LJO https://github.com/speechly/nlu-example-parser/releases/download/${VERSION}/${FILENAME}
 $ tar -xzf ${FILENAME}
 ```


### PR DESCRIPTION
### What

Change release build naming and fix verification step and update README.

### Why

Simpler artifact naming makes downloading latest version easier.
