### PR TITLE
Add handling for syntax errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,6 @@ vendor/
 # IDE files
 .idea/
 .vscode/
+
+# OS files
+.DS_Store

--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,7 @@ test:
 
 verify: static-build
 	./bin/golden -input_file_path ./examples/test_multi_intent_data.md | diff - test/golden.json
+	./bin/golden -input_file_path ./examples/test_incorrect_data.md 2>&1 | diff - test/golden_error
 .PHONY: verify
 
 static-build:

--- a/README.md
+++ b/README.md
@@ -22,8 +22,6 @@ Usage of nlu-example-parser:
     path to input file (required)
   -buffer_size_mb uint
     size of the input and output buffers for input and output files (default 1)
-  -debug bool
-    enable debug output (default false)
   -parser_buffer_size_lines uint
     size of the buffer with parsed lines (default 100)
 ```
@@ -90,13 +88,12 @@ import (
 )
 
 const (
-	debug         = false
 	testUtterance = "*change change the [kitchen door    knobs](object)! *_ and *remove remove  the [table](object)"
 )
 
 func main() {
 	// Create a new parser.
-	p := parser.NewParser(debug)
+	p := parser.NewParser()
 
 	// Consume the results.
 	done := make(chan struct{})
@@ -134,7 +131,6 @@ import (
 
 const (
 	bufSize = 10
-	debug   = false
 	verbose = false
 
 	testUtterance = "*change change the [kitchen door    knobs](object)! *_ and *remove remove  the [table](object)"
@@ -144,7 +140,7 @@ func main() {
 	ctx := context.Background()
 
 	// Create a new parser.
-	p := parser.NewStreamParser(bufSize, debug, verbose)
+	p := parser.NewStreamParser(bufSize, verbose)
 
 	// Start the parser.
 	if err := p.Start(ctx); err != nil {
@@ -189,7 +185,6 @@ import (
 const (
 	bufSize       = 10
 	parserBufSize = 10
-	debug         = false
 
 	testUtterance = "*change change the [kitchen door    knobs](object)! *_ and *remove remove  the [table](object)\n"
 )
@@ -198,7 +193,7 @@ func main() {
 	var wg sync.WaitGroup
 
 	r := strings.NewReader(testUtterance)
-	parser := parser.NewIOParser(bufSize, parserBufSize, debug)
+	parser := parser.NewIOParser(bufSize, parserBufSize)
 
 	wg.Add(1)
 	go func() {

--- a/cmd/parser/main.go
+++ b/cmd/parser/main.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"strings"
 
 	"github.com/speechly/nlu-example-parser/pkg/parser"
 
@@ -19,8 +20,7 @@ const (
 var (
 	inputFileFlag     = flag.String("input_file_path", "", "path to input file")
 	bufSizeFlag       = flag.Uint64("buffer_size_mb", 1, "size of the input and output buffers for input and output files")
-	parserBufSizeFlag = flag.Uint64("parser_buffer_size_lines", 100, "size of the buffer with parsed lines")
-	debugFlag         = flag.Bool("debug", false, "enable debug output")
+	parserBufSizeFlag = flag.Uint("parser_buffer_size_lines", 100, "size of the buffer with parsed lines")
 )
 
 func main() {
@@ -49,7 +49,7 @@ func main() {
 		os.Exit(printErr(err))
 	}
 
-	parser := parser.NewIOParser(bufSize, parserBufSize, *debugFlag)
+	parser := parser.NewIOParser(bufSize, uint16(parserBufSize))
 
 	g, _ := errgroup.WithContext(context.Background())
 	g.Go(func() error {
@@ -123,6 +123,9 @@ func main() {
 }
 
 func printErr(err error) int {
-	fmt.Fprintf(os.Stderr, "parser encountered an error: %s\n", err.Error())
+	for _, l := range strings.Split(err.Error(), "\n") {
+		fmt.Fprintf(os.Stderr, "{\"error\":\"%s\"}\n", l)
+	}
+
 	return 1
 }

--- a/examples/test_incorrect_data.md
+++ b/examples/test_incorrect_data.md
@@ -1,0 +1,2 @@
+*move change the [desk](object) position [1.5 meters left](direction) *_ and *add add 100 [windows](object)
+.change change the [kitchen door    knobs](object)! *_ and *remove remove  the [table](object)

--- a/examples/test_multi_intent_data.md
+++ b/examples/test_multi_intent_data.md
@@ -1,2 +1,2 @@
-*change change the [kitchen door    knobs](object)! *_ and *remove remove  the [table](object)
+.change change the [kitchen door    knobs](object)! *_ and *remove remove  the [table](object)
 *move change the [desk](object) position [1.5 meters left](direction) *_ and *add add 100 [windows](object)

--- a/examples/test_multi_intent_data.md
+++ b/examples/test_multi_intent_data.md
@@ -1,2 +1,2 @@
-.change change the [kitchen door    knobs](object)! *_ and *remove remove  the [table](object)
+*change change the [kitchen door    knobs](object)! *_ and *remove remove  the [table](object)
 *move change the [desk](object) position [1.5 meters left](direction) *_ and *add add 100 [windows](object)

--- a/internal/grammar/error_handler.go
+++ b/internal/grammar/error_handler.go
@@ -1,0 +1,89 @@
+package grammar
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/antlr/antlr4/runtime/Go/antlr"
+)
+
+type ParseError struct {
+	buf   strings.Builder
+	count uint64
+}
+
+func (p *ParseError) Append(e ParseError) {
+	var s string
+	if p.count > 0 {
+		s = "\n" + e.Error()
+	} else {
+		s = e.Error()
+	}
+
+	p.buf.WriteString(s)
+	p.count++
+}
+
+func (p ParseError) Len() uint64 {
+	return p.count
+}
+
+func (p ParseError) Error() string {
+	return p.buf.String()
+}
+
+func NewParseError(s string) ParseError {
+	var b strings.Builder
+	b.WriteString(s)
+
+	return ParseError{
+		buf: b,
+	}
+}
+
+type NLUExampleErrorListener struct {
+	errs    chan ParseError
+	verbose bool
+}
+
+func (l *NLUExampleErrorListener) SyntaxError(r antlr.Recognizer, sym interface{}, line, col int, msg string, e antlr.RecognitionException) {
+	l.errs <- NewParseError(fmt.Sprintf("SyntaxError: %s %d:%d", msg, line, col))
+}
+
+func (l *NLUExampleErrorListener) ReportAmbiguity(recognizer antlr.Parser, dfa *antlr.DFA, startIndex, stopIndex int, exact bool, ambigAlts *antlr.BitSet, configs antlr.ATNConfigSet) {
+	if !l.verbose {
+		return
+	}
+
+	l.errs <- NewParseError(fmt.Sprintf("AmbiguityError: %d:%d", startIndex, stopIndex))
+}
+
+func (l *NLUExampleErrorListener) ReportAttemptingFullContext(recognizer antlr.Parser, dfa *antlr.DFA, startIndex, stopIndex int, conflictingAlts *antlr.BitSet, configs antlr.ATNConfigSet) {
+	if !l.verbose {
+		return
+	}
+
+	l.errs <- NewParseError(fmt.Sprintf("ContextError: %d:%d", startIndex, stopIndex))
+}
+
+func (l *NLUExampleErrorListener) ReportContextSensitivity(recognizer antlr.Parser, dfa *antlr.DFA, startIndex, stopIndex, prediction int, configs antlr.ATNConfigSet) {
+	if !l.verbose {
+		return
+	}
+
+	l.errs <- NewParseError(fmt.Sprintf("ContextError: %d:%d", startIndex, stopIndex))
+}
+
+func (l *NLUExampleErrorListener) Errors() <-chan ParseError {
+	return l.errs
+}
+
+func (l *NLUExampleErrorListener) Close() {
+	close(l.errs)
+}
+
+func NewNLUExampleErrorListener(bufSize uint16, verbose bool) *NLUExampleErrorListener {
+	return &NLUExampleErrorListener{
+		errs: make(chan ParseError, bufSize),
+	}
+}

--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -6,9 +6,37 @@ import (
 	"github.com/speechly/nlu-example-parser/internal/grammar"
 )
 
+
+type NluParsingErrorListener struct {
+	errors int
+}
+
+func (l *NluParsingErrorListener) SyntaxError(recognizer antlr.Recognizer, offendingSymbol interface{}, line, column int, msg string, e antlr.RecognitionException) {
+	l.errors += 1
+}
+
+func (l *NluParsingErrorListener) ReportAmbiguity(recognizer antlr.Parser, dfa *antlr.DFA, startIndex, stopIndex int, exact bool, ambigAlts *antlr.BitSet, configs antlr.ATNConfigSet) {
+	l.errors += 1
+}
+
+func (l *NluParsingErrorListener) ReportAttemptingFullContext(recognizer antlr.Parser, dfa *antlr.DFA, startIndex, stopIndex int, conflictingAlts *antlr.BitSet, configs antlr.ATNConfigSet) {
+	l.errors += 1
+}
+
+func (l *NluParsingErrorListener) ReportContextSensitivity(recognizer antlr.Parser, dfa *antlr.DFA, startIndex, stopIndex, prediction int, configs antlr.ATNConfigSet) {
+	l.errors += 1
+}
+
+func NewNluParsingErrorListener() *NluParsingErrorListener {
+	return &NluParsingErrorListener{
+		errors: 0,
+	}
+}
+
 type Parser struct {
 	lis   *grammar.NluRuleListener
 	debug bool
+	errLis NluParsingErrorListener
 }
 
 func NewParser(debug bool) *Parser {
@@ -19,6 +47,7 @@ func NewBufferedParser(bufSize uint64, debug bool) *Parser {
 	return &Parser{
 		lis:   grammar.NewNluRuleListener(bufSize, debug),
 		debug: debug,
+		errLis: NluParsingErrorListener(),
 	}
 }
 
@@ -39,6 +68,8 @@ func (p *Parser) Parse(line string) {
 		parse.AddErrorListener(antlr.NewDiagnosticErrorListener(p.debug))
 	}
 
+	parse.AddErrorListener(errLis)
+
 	antlr.ParseTreeWalkerDefault.Walk(p.lis, parse.Annotation())
 }
 
@@ -48,4 +79,9 @@ func (p *Parser) Results() <-chan grammar.Utterance {
 
 func (p *Parser) Close() {
 	p.lis.Close()
+	p.errLis.Close()
+}
+
+func (p *Parser) Errors() <-chan error {
+	return p.errLis.Errs()
 }

--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -47,7 +47,7 @@ func NewBufferedParser(bufSize uint64, debug bool) *Parser {
 	return &Parser{
 		lis:   grammar.NewNluRuleListener(bufSize, debug),
 		debug: debug,
-		errLis: NluParsingErrorListener(),
+		errLis: NewNluParsingErrorListener(),
 	}
 }
 
@@ -68,7 +68,7 @@ func (p *Parser) Parse(line string) {
 		parse.AddErrorListener(antlr.NewDiagnosticErrorListener(p.debug))
 	}
 
-	parse.AddErrorListener(errLis)
+	parse.AddErrorListener(p.errLis)
 
 	antlr.ParseTreeWalkerDefault.Walk(p.lis, parse.Annotation())
 }

--- a/pkg/parser/stream_parser.go
+++ b/pkg/parser/stream_parser.go
@@ -16,7 +16,7 @@ type StreamParser struct {
 
 func NewStreamParser(bufSize uint64, debug bool, verbose bool) *StreamParser {
 	return &StreamParser{
-		parse:   NewParser(debug),
+		parse:   NewParser(),
 		ch:      make(chan string, bufSize),
 		done:    make(chan struct{}),
 		debug:   debug,

--- a/test/golden_error
+++ b/test/golden_error
@@ -1,0 +1,6 @@
+{"error":"SyntaxError: extraneous input '.change' expecting {'*', WHITESPACE} 1:0"}
+{"error":"SyntaxError: extraneous input 'change' expecting {'*', WHITESPACE} 1:8"}
+{"error":"SyntaxError: extraneous input 'the' expecting {'*', WHITESPACE} 1:15"}
+{"error":"SyntaxError: extraneous input '[' expecting {'*', WHITESPACE} 1:19"}
+{"error":"SyntaxError: extraneous input 'door' expecting {'*', WHITESPACE} 1:28"}
+{"error":"SyntaxError: extraneous input 'knobs' expecting {'*', WHITESPACE} 1:36"}


### PR DESCRIPTION
### What

Handle syntax errors and bubble them up to the highest level. The parser will exit with status 1 if any syntax error is detected. The errors are outputted in JSON format.

### Why

So that it's possible to easily report back any errors found in the input file.

An example output looks like this:
```sh
$ ./bin/parser -input_file_path ./examples/test_incorrect_data.md
{"error":"SyntaxError: extraneous input '.change' expecting {'*', WHITESPACE} 1:0"}
{"error":"SyntaxError: extraneous input 'change' expecting {'*', WHITESPACE} 1:8"}
{"error":"SyntaxError: extraneous input 'the' expecting {'*', WHITESPACE} 1:15"}
{"error":"SyntaxError: extraneous input '[' expecting {'*', WHITESPACE} 1:19"}
{"error":"SyntaxError: extraneous input 'door' expecting {'*', WHITESPACE} 1:28"}
{"error":"SyntaxError: extraneous input 'knobs' expecting {'*', WHITESPACE} 1:36"}
$ echo $?
1
```

And it's possible to use e.g. `jq` to parse those (NB: the errors are printed to `stderr`):
```sh
$ ./bin/parser -input_file_path ./examples/test_incorrect_data.md 2>&1 | jq .
{
  "error": "SyntaxError: extraneous input '.change' expecting {'*', WHITESPACE} 1:0"
}
{
  "error": "SyntaxError: extraneous input 'change' expecting {'*', WHITESPACE} 1:8"
}
{
  "error": "SyntaxError: extraneous input 'the' expecting {'*', WHITESPACE} 1:15"
}
{
  "error": "SyntaxError: extraneous input '[' expecting {'*', WHITESPACE} 1:19"
}
{
  "error": "SyntaxError: extraneous input 'door' expecting {'*', WHITESPACE} 1:28"
}
{
  "error": "SyntaxError: extraneous input 'knobs' expecting {'*', WHITESPACE} 1:36"
}
```
